### PR TITLE
OMDI-11 : Modify validation to require one date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
             <artifactId>ddi-validator</artifactId>
             <!--<version>1.1</version>-->
             <!--<version>1.1.3-SNAPSHOT</version>-->
-            <version>1.3.1-SNAPSHOT</version>
+            <version>1.3.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
maven build fails when we try to building with dependency of ddi-validator